### PR TITLE
add frame interface and different frame types

### DIFF
--- a/src/blackbox/frame.go
+++ b/src/blackbox/frame.go
@@ -1,24 +1,104 @@
 package blackbox
 
-// Frame represents a frame
-type Frame struct {
-	Type   string
-	Start  int64
-	End    int64
-	Values []int32
+// See https://cleanflight.readthedocs.io/en/stable/development/Blackbox%20Internals/
+
+type Frame interface {
+	Type() LogFrameType
+	Values() interface{}
+	Size() int
 }
 
-// NewFrame returns a new frame
-func NewFrame(frameType string, values []int32, start, end int64) *Frame {
-	return &Frame{
-		Type:   frameType,
-		Values: values,
-		Start:  start,
-		End:    end,
-	}
+// -------------------------------------------------------------------------- //
+
+type baseFrame struct {
+	frameType LogFrameType
+	start     int64
+	end       int64
+}
+
+func (f baseFrame) Type() LogFrameType {
+	return f.frameType
 }
 
 // Size returns the size in bytes of a Frame
-func (f *Frame) Size() int {
-	return int(f.End - f.Start)
+func (f baseFrame) Size() int {
+	return int(f.end - f.start)
+}
+
+// -------------------------------------------------------------------------- //
+
+// Frame represents a frame
+type MainFrame struct {
+	baseFrame
+	values []int32
+}
+
+// NewFrame returns a new frame
+func NewMainFrame(frameType LogFrameType, values []int32, start, end int64) *MainFrame {
+	return &MainFrame{
+		values: values,
+		baseFrame: baseFrame{
+			frameType: frameType,
+			start:     start,
+			end:       end,
+		},
+	}
+}
+
+func (f MainFrame) Values() interface{} {
+	return f.values
+}
+
+// -------------------------------------------------------------------------- //
+
+// Frame represents a frame
+type SlowFrame struct {
+	baseFrame
+	values []int32
+}
+
+// NewFrame returns a new frame
+func NewSlowFrame(values []int32, start, end int64) *SlowFrame {
+	return &SlowFrame{
+		values: values,
+		baseFrame: baseFrame{
+			frameType: LogFrameSlow,
+			start:     start,
+			end:       end,
+		},
+	}
+}
+
+func (f SlowFrame) Values() interface{} {
+	return f.values
+}
+
+// -------------------------------------------------------------------------- //
+
+type eventValues = map[string]interface{}
+
+type EventFrame struct {
+	baseFrame
+	eventType LogEventType
+	values    eventValues
+}
+
+func NewEventFrame(eventType LogEventType, values eventValues, start, end int64) *EventFrame {
+	return &EventFrame{
+		eventType: eventType,
+		values:    values,
+		baseFrame: baseFrame{
+			frameType: LogFrameEvent,
+			start:     start,
+			end:       end,
+		},
+	}
+}
+
+func (f EventFrame) Values() interface{} {
+	return f.values
+}
+
+func (f EventFrame) EventType() LogEventType {
+	return f.eventType
 }

--- a/src/blackbox/logdefinition.go
+++ b/src/blackbox/logdefinition.go
@@ -4,6 +4,30 @@ import (
 	"github.com/pkg/errors"
 )
 
+type LogFrameType string
+
+const (
+	// See https://cleanflight.readthedocs.io/en/stable/development/Blackbox%20Internals/
+	LogFrameEvent LogFrameType = "E"
+	LogFrameIntra              = "I"
+	LogFrameInter              = "P"
+	LogFrameSlow               = "S"
+)
+
+// -------------------------------------------------------------------------- //
+
+type LogEventType int32
+
+const (
+	LogEventSyncBeep           LogEventType = 0
+	LogEventInflightAdjustment              = 13
+	LogEventLoggingResume                   = 14
+	LogEventFlightMode                      = 30
+	LogEventLogEnd                          = 255
+)
+
+// -------------------------------------------------------------------------- //
+
 const (
 	firmwareTypeUnknown = "Unknown firmware"
 )

--- a/src/blackbox/parser.go
+++ b/src/blackbox/parser.go
@@ -29,7 +29,7 @@ const (
 )
 
 // ParseFrame parse any kind of data frame and applies prediction
-func ParseFrame(frameDef LogDefinition, fields []FieldDefinition, previousFrame, previousPreviousFrame *Frame, dec *stream.Decoder, disablePredicator bool, skippedFrames int32) ([]int32, error) {
+func ParseFrame(frameDef LogDefinition, fields []FieldDefinition, previousFrame, previousPreviousFrame *MainFrame, dec *stream.Decoder, disablePredicator bool, skippedFrames int32) ([]int32, error) {
 	frameValues := make([]int32, len(fields))
 	framesToSkip := 0
 	for i, field := range fields {
@@ -48,7 +48,7 @@ func ParseFrame(frameDef LogDefinition, fields []FieldDefinition, previousFrame,
 		if field.Predictor == PredictorInc {
 			frameValues[i] = skippedFrames + 1
 			if previousFrame != nil {
-				frameValues[i] += previousFrame.Values[i]
+				frameValues[i] += previousFrame.values[i]
 			}
 			continue
 		}

--- a/src/blackbox/parser_test.go
+++ b/src/blackbox/parser_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/maxlaverse/blackbox-library/src/blackbox/stream"
+	"github.com/stretchr/testify/assert"
 )
 
 var encodedFrameI = []byte{73, 128, 163, 3, 251, 171, 176, 26, 0, 4, 0, 6, 3, 3, 10, 6, 0, 0, 0, 3, 0, 0, 192, 9, 1, 0, 0, 176, 3, 233, 1, 166, 11, 145, 6, 1, 3, 0, 54, 116, 250, 34, 4, 14, 0, 0, 140, 3, 35, 36, 38}
@@ -86,11 +86,11 @@ func TestParseFramePPredicted(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, decodedPredictedFrameI, res)
 
-	previousPreviousFrame := &Frame{
-		Values: res,
+	previousPreviousFrame := &MainFrame{
+		values: res,
 	}
-	previousFrame := &Frame{
-		Values: res,
+	previousFrame := &MainFrame{
+		values: res,
 	}
 
 	for idx, decodedFrame := range decodedPredictedFramesP {
@@ -100,8 +100,8 @@ func TestParseFramePPredicted(t *testing.T) {
 			assert.Equal(t, decodedFrame, res)
 
 			previousPreviousFrame = previousFrame
-			previousFrame = &Frame{
-				Values: res,
+			previousFrame = &MainFrame{
+				values: res,
 			}
 		})
 	}

--- a/src/blackbox/predictor.go
+++ b/src/blackbox/predictor.go
@@ -43,7 +43,7 @@ const (
 )
 
 // ApplyPrediction a predictor on a field and return the resulting value
-func ApplyPrediction(frameDef LogDefinition, values []int32, fieldIndex int, predictor int, value int32, previous *Frame, previous2 *Frame) (int32, error) {
+func ApplyPrediction(frameDef LogDefinition, values []int32, fieldIndex int, predictor int, value int32, previous *MainFrame, previous2 *MainFrame) (int32, error) {
 
 	// First see if we have a prediction that doesn't require a previous frame as reference:
 	switch predictor {
@@ -66,17 +66,17 @@ func ApplyPrediction(frameDef LogDefinition, values []int32, fieldIndex int, pre
 		if previous == nil {
 			break
 		}
-		value = value + previous.Values[fieldIndex]
+		value = value + previous.values[fieldIndex]
 	case PredictorStraightLine:
 		if previous == nil {
 			break
 		}
-		value = value + 2*previous.Values[fieldIndex] - previous2.Values[fieldIndex]
+		value = value + 2*previous.values[fieldIndex] - previous2.values[fieldIndex]
 	case PredicatorAverage2:
 		if previous == nil {
 			break
 		}
-		value = value + (previous.Values[fieldIndex]+previous2.Values[fieldIndex])/2
+		value = value + (previous.values[fieldIndex]+previous2.values[fieldIndex])/2
 	case PredictorMinMotor:
 		value += int32(frameDef.Sysconfig.MotorOutputLow)
 	default:

--- a/src/blackbox/reader.go
+++ b/src/blackbox/reader.go
@@ -58,7 +58,7 @@ func (f *FlightLogReader) LoadFile(file io.Reader) error {
 			continue
 		}
 
-		f.Frames = append(f.Frames, *frame)
+		f.Frames = append(f.Frames, frame)
 	}
 
 	frameReader.PrintStatistics()

--- a/src/blackbox/reader_frame_test.go
+++ b/src/blackbox/reader_frame_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/maxlaverse/blackbox-library/src/blackbox/stream"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReadFrameI(t *testing.T) {
@@ -19,7 +19,7 @@ func TestReadFrameI(t *testing.T) {
 
 	frame, err := frameReader.ReadNextFrame()
 	assert.Nil(t, err)
-	assert.Equal(t, &Frame{Type: "I", Start: 0, End: 51, Values: decodedPredictedFrameI}, frame)
+	assert.Equal(t, NewMainFrame(LogFrameIntra, decodedPredictedFrameI, 0, 51), frame)
 }
 
 func TestReadFrameS(t *testing.T) {
@@ -32,7 +32,7 @@ func TestReadFrameS(t *testing.T) {
 
 	frame, err := frameReader.ReadNextFrame()
 	assert.Nil(t, err)
-	assert.Equal(t, &Frame{Type: "S", Start: 0, End: 1, Values: []int32{}}, frame)
+	assert.Equal(t, NewSlowFrame([]int32{}, 0, 1), frame)
 }
 
 func TestReadFrameEventLoggingResume(t *testing.T) {
@@ -45,7 +45,7 @@ func TestReadFrameEventLoggingResume(t *testing.T) {
 
 	frame, err := frameReader.ReadNextFrame()
 	assert.Nil(t, err)
-	assert.Equal(t, &Frame{Type: "E", Start: 0, End: 9, Values: nil}, frame)
+	assert.Equal(t, NewEventFrame(LogEventSyncBeep, nil, 0, 9), frame)
 	assert.Equal(t, int32(55158008), frameReader.LoggingResumeCurrentTime)
 	assert.Equal(t, int32(52992), frameReader.LoggingResumeLogIteration)
 }
@@ -60,7 +60,7 @@ func TestReadFrameEventSyncBeep(t *testing.T) {
 
 	frame, err := frameReader.ReadNextFrame()
 	assert.Nil(t, err)
-	assert.Equal(t, &Frame{Type: "E", Start: 0, End: 6, Values: nil}, frame)
+	assert.Equal(t, NewEventFrame(LogEventSyncBeep, nil, 0, 6), frame)
 }
 
 func TestReadFrameEventLogEnd(t *testing.T) {
@@ -73,7 +73,7 @@ func TestReadFrameEventLogEnd(t *testing.T) {
 
 	frame, err := frameReader.ReadNextFrame()
 	assert.Nil(t, err)
-	assert.Equal(t, &Frame{Type: "E", Start: 0, End: 12, Values: nil}, frame)
+	assert.Equal(t, NewEventFrame(LogEventSyncBeep, nil, 0, 12), frame)
 	assert.Equal(t, true, frameReader.Finished)
 }
 
@@ -97,14 +97,14 @@ func TestReadStream(t *testing.T) {
 
 	frameReader := NewFrameReader(&dec, frameDef, nil)
 
-	decodedFrames := []*Frame{
-		&Frame{Type: "I", Start: 0, End: 51, Values: decodedPredictedFrameI},
-		&Frame{Type: "P", Start: 51, End: 80, Values: decodedPredictedFramesP[0]},
-		&Frame{Type: "P", Start: 80, End: 108, Values: decodedPredictedFramesP[1]},
-		&Frame{Type: "P", Start: 108, End: 136, Values: decodedPredictedFramesP[2]},
-		&Frame{Type: "P", Start: 136, End: 164, Values: decodedPredictedFramesP[3]},
-		&Frame{Type: "P", Start: 164, End: 194, Values: decodedPredictedFramesP[4]},
-		&Frame{Type: "P", Start: 194, End: 224, Values: decodedPredictedFramesP[5]},
+	decodedFrames := []Frame{
+		NewMainFrame(LogFrameIntra, decodedPredictedFrameI, 0, 51),
+		NewMainFrame(LogFrameInter, decodedPredictedFramesP[0], 51, 80),
+		NewMainFrame(LogFrameInter, decodedPredictedFramesP[1], 80, 108),
+		NewMainFrame(LogFrameInter, decodedPredictedFramesP[2], 108, 136),
+		NewMainFrame(LogFrameInter, decodedPredictedFramesP[3], 136, 164),
+		NewMainFrame(LogFrameInter, decodedPredictedFramesP[4], 164, 194),
+		NewMainFrame(LogFrameInter, decodedPredictedFramesP[5], 194, 224),
 	}
 
 	for idx, decodedFrame := range decodedFrames {
@@ -124,10 +124,10 @@ func TestReadBrokenFrame(t *testing.T) {
 
 	frameReader := NewFrameReader(&dec, frameDef, nil)
 
-	decodedFrames := []*Frame{
-		&Frame{Type: "I", Start: 0, End: 51, Values: decodedPredictedFrameI},
-		&Frame{Type: "P", Start: 51, End: 80, Values: decodedPredictedFramesP[0]},
-		&Frame{Type: "P", Start: 80, End: 108, Values: decodedPredictedFramesP[1]},
+	decodedFrames := []Frame{
+		NewMainFrame(LogFrameIntra, decodedPredictedFrameI, 0, 51),
+		NewMainFrame(LogFrameInter, decodedPredictedFramesP[0], 51, 80),
+		NewMainFrame(LogFrameInter, decodedPredictedFramesP[1], 80, 108),
 	}
 
 	for idx, decodedFrame := range decodedFrames {

--- a/src/blackbox/stats.go
+++ b/src/blackbox/stats.go
@@ -5,7 +5,7 @@ type StatsType struct {
 	TotalCorruptedFrames          int
 	IntentionallyAbsentIterations int
 	TotalFrames                   int
-	Frame                         map[string]StatsFrameType
+	Frame                         map[LogFrameType]StatsFrameType
 }
 
 // StatsFrameType represents stats for one type of freame

--- a/src/exporter/blackbox_decode/main.go
+++ b/src/exporter/blackbox_decode/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/maxlaverse/blackbox-library/src/exporter/exporter"
 	"os"
 	"path"
 	"strconv"
@@ -66,5 +67,5 @@ func export(sourceFilepath string, opts cmdOptions) error {
 	}
 	defer csvFile.Close()
 
-	return writeToCsv(&flightLog, csvFile)
+	return exporter.WriteToCsv(&flightLog, csvFile)
 }


### PR DESCRIPTION
If we want to make this lib public and reusable, it makes sense if we stick to the [official frames structure](https://cleanflight.readthedocs.io/en/stable/development/Blackbox%20Internals/).
I added here a frame interface and its implementations for frame types which we already use (main, slow, event)
All the other changes - are refactorings to make the interface fit to the previous logic.