### PR TITLE
Handling errors

### DIFF
--- a/src/blackbox/logdefinition.go
+++ b/src/blackbox/logdefinition.go
@@ -4,19 +4,30 @@ import (
 	"github.com/pkg/errors"
 )
 
-type LogFrameType string
+type LogFrameType = byte
 
 const (
 	// See https://cleanflight.readthedocs.io/en/stable/development/Blackbox%20Internals/
-	LogFrameEvent LogFrameType = "E"
-	LogFrameIntra              = "I"
-	LogFrameInter              = "P"
-	LogFrameSlow               = "S"
+	LogFrameEvent  LogFrameType = 69 // E
+	LogFrameIntra               = 73 // I
+	LogFrameInter               = 80 // P
+	LogFrameSlow                = 83 // S
+	LogFrameHeader              = 72 // H
+	LogFrameGPS                 = 71 // G
 )
+
+var LogFrameAllTypes = []byte{
+	LogFrameEvent,
+	LogFrameIntra,
+	LogFrameInter,
+	LogFrameSlow,
+	LogFrameHeader,
+	LogFrameGPS,
+}
 
 // -------------------------------------------------------------------------- //
 
-type LogEventType int32
+type LogEventType = byte
 
 const (
 	LogEventSyncBeep           LogEventType = 0

--- a/src/blackbox/reader.go
+++ b/src/blackbox/reader.go
@@ -2,6 +2,7 @@ package blackbox
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 
@@ -75,7 +76,7 @@ func consumeToNext(enc stream.Decoder) int64 {
 		}
 
 		fmt.Printf("%d:%v, ", i, string(b))
-		if string(b) == "S" || string(b) == "H" || string(b) == "E" || string(b) == "I" || string(b) == "P" || string(b) == "G" {
+		if bytes.IndexByte(LogFrameAllTypes, b) != -1 {
 			newPos := enc.BytesRead()
 			return newPos - intialPos
 		}

--- a/src/blackbox/reader.go
+++ b/src/blackbox/reader.go
@@ -3,7 +3,7 @@ package blackbox
 import (
 	"bufio"
 	"bytes"
-	"fmt"
+	"github.com/pkg/errors"
 	"io"
 
 	"github.com/maxlaverse/blackbox-library/src/blackbox/stream"
@@ -50,37 +50,47 @@ func (f *FlightLogReader) LoadFile(file io.Reader) error {
 		Raw: false,
 	}
 
-	frameReader := NewFrameReader(&decoder, frameDefinition, opts)
+	frameReader, err := NewFrameReader(&decoder, frameDefinition, opts)
+	if err != nil {
+		return err
+	}
+
 	for !frameReader.Finished {
 		frame, err := frameReader.ReadNextFrame()
-		if err != nil {
-			fmt.Printf("Frame was discarded: %v\n", err)
-			consumeToNext(decoder)
+		if err == nil {
+			f.Frames = append(f.Frames, frame)
 			continue
 		}
 
-		f.Frames = append(f.Frames, frame)
+		// @TODO: consume skippedFrames
+		_, err = consumeToNext(decoder)
+		if err != nil {
+			return err
+		}
 	}
 
 	frameReader.PrintStatistics()
 	return nil
 }
 
-func consumeToNext(enc stream.Decoder) int64 {
-	defer fmt.Printf("\n")
-	intialPos := enc.BytesRead()
+func consumeToNext(enc stream.Decoder) (skippedFrames int64, err error) {
+	initialPos := enc.BytesRead()
 	for i := 0; i < 256; i++ {
 		b, err := enc.NextByte()
 		if err != nil {
-			panic(err)
+			return 0, err
 		}
 
-		fmt.Printf("%d:%v, ", i, string(b))
 		if bytes.IndexByte(LogFrameAllTypes, b) != -1 {
 			newPos := enc.BytesRead()
-			return newPos - intialPos
+			return newPos - initialPos, nil
 		}
-		enc.ReadByte()
+
+		_, err = enc.ReadByte()
+		if err != nil {
+			return 0, err
+		}
 	}
-	panic("Could not find next frame")
+
+	return 0, errors.New("FlightLogReader: could not find next frame")
 }

--- a/src/blackbox/reader_frame.go
+++ b/src/blackbox/reader_frame.go
@@ -45,14 +45,14 @@ type FrameReaderOptions struct {
 }
 
 // NewFrameReader returns a new FrameReader
-func NewFrameReader(dec *stream.Decoder, frameDef LogDefinition, opts *FrameReaderOptions) FrameReader {
+func NewFrameReader(dec *stream.Decoder, frameDef LogDefinition, opts *FrameReaderOptions) (*FrameReader, error) {
 	val, err := frameDef.GetHeaderValue("I interval")
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	frameIntervalI, err := strconv.ParseInt(val, 10, 32)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	if frameIntervalI < 1 {
 		frameIntervalI = 1
@@ -76,7 +76,7 @@ func NewFrameReader(dec *stream.Decoder, frameDef LogDefinition, opts *FrameRead
 	if opts != nil {
 		frameReader.raw = opts.Raw
 	}
-	return frameReader
+	return &frameReader, nil
 }
 
 // ReadNextFrame reads the next frame
@@ -90,17 +90,16 @@ func (f *FrameReader) ReadNextFrame() (Frame, error) {
 	frameType := LogFrameType(command)
 
 	//Next byte should be readable if stream is valid
-	switch frameType {
+	switch command {
 	case LogFrameEvent:
-		err := f.parseEventFrame(f.dec)
+		eventType, eventValues, err := f.parseEventFrame(f.dec)
 		if err != nil {
 			return nil, err
 		}
 		end := f.dec.BytesRead()
-		// @TODO: parse event properly
-		frame := NewEventFrame(LogEventSyncBeep, nil, start, end)
-		f.PreComplete(frame)
-		return frame, nil
+		frame := NewEventFrame(*eventType, eventValues, start, end)
+		_, err = f.PreComplete(frame)
+		return frame, err
 
 	case LogFrameIntra:
 		values, err := ParseFrame(f.frameDef, f.frameDef.FieldsI, f.Previous, f.PreviousPrevious, f.dec, f.raw, f.LastSkippedFrames)
@@ -109,8 +108,8 @@ func (f *FrameReader) ReadNextFrame() (Frame, error) {
 		}
 		end := f.dec.BytesRead()
 		frame := NewMainFrame(frameType, values, start, end)
-		f.PreComplete(frame)
-		return frame, nil
+		_, err = f.PreComplete(frame)
+		return frame, err
 
 	case LogFrameInter:
 		f.LastSkippedFrames = f.countIntentionallySkippedFrames()
@@ -120,8 +119,8 @@ func (f *FrameReader) ReadNextFrame() (Frame, error) {
 		}
 		end := f.dec.BytesRead()
 		frame := NewMainFrame(frameType, values, start, end)
-		f.PreComplete(frame)
-		return frame, nil
+		_, err = f.PreComplete(frame)
+		return frame, err
 
 	case LogFrameSlow:
 		values, err := ParseFrame(f.frameDef, f.frameDef.FieldsS, nil, nil, f.dec, f.raw, 0)
@@ -130,8 +129,8 @@ func (f *FrameReader) ReadNextFrame() (Frame, error) {
 		}
 		end := f.dec.BytesRead()
 		frame := NewSlowFrame(values, start, end)
-		f.PreComplete(frame)
-		return frame, nil
+		_, err = f.PreComplete(frame)
+		return frame, err
 
 	default:
 		//TODO: If a P frame is corrupt here, we should optionally drop the previous one (As the original implementation does)
@@ -141,126 +140,134 @@ func (f *FrameReader) ReadNextFrame() (Frame, error) {
 	}
 }
 
-func (f *FrameReader) parseEventFrame(dec *stream.Decoder) error {
-	event, err := dec.ReadByte()
+func (f *FrameReader) parseEventFrame(dec *stream.Decoder) (*LogEventType, eventValues, error) {
+	values := make(eventValues)
+	eventType, err := dec.ReadByte()
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
-	f.LastEventType = &event
+	f.LastEventType = &eventType
 
-	switch event {
+	switch eventType {
 	case LogEventSyncBeep:
 		beepTime, err := dec.ReadUnsignedVB()
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
-		fmt.Printf("Frame #X (E) ")
-		fmt.Printf("%s=%d ", "beepTime", beepTime)
-		fmt.Printf("\n")
+		values["beepTime"] = beepTime
+
 	case LogEventInflightAdjustment:
-		fmt.Printf("Event type is logEventInflightAdjustment\n")
-		panic("Not implemented: logEventInflightAdjustment")
+		return nil, nil, errors.New("Not implemented: logEventInflightAdjustment")
+
 	case LogEventLoggingResume:
 		val, err := dec.ReadUnsignedVB()
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		f.LoggingResumeLogIteration = int32(val)
 
 		val, err = dec.ReadUnsignedVB()
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		f.LoggingResumeCurrentTime = int32(val) + f.timeRolloverAccumulator
+		values["iteration"] = f.LoggingResumeLogIteration
+		values["currentTime"] = f.LoggingResumeCurrentTime
 
-		fmt.Printf("Frame #X (%s) ", "E")
-		fmt.Printf("%s=%d ", "iteration", f.LoggingResumeLogIteration)
-		fmt.Printf("%s=%d ", "currentTime", f.LoggingResumeCurrentTime)
-		fmt.Printf("\n")
 	case LogEventFlightMode:
-		fmt.Printf("Frame #X (%s) ", "E")
 		flags, err := dec.ReadUnsignedVB()
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
-		fmt.Printf("%s=%d ", "flags", flags)
-
 		lastFlags, err := dec.ReadUnsignedVB()
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
-		fmt.Printf("%s=%d ", "lastFlags", lastFlags)
-		fmt.Printf("\n")
-	case LogEventLogEnd:
+		values["flags"] = flags
+		values["lastFlags"] = lastFlags
 
+	case LogEventLogEnd:
 		val, err := dec.ReadBytes(12)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
-		fmt.Printf("Frame #X (%s) ", "E")
-		fmt.Printf("data=%s ", val)
-		fmt.Printf("\n")
+
 		reachedEndOfFile, err := dec.EOF()
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		if !reachedEndOfFile {
-			return errors.New("There are additional data after the end of the file")
+			return nil, nil, errors.New("There are additional data after the end of the file")
 		}
 		f.Finished = true
+		values["data"] = val
+
 	default:
-		fmt.Printf("Event type is unknown - ignored: %v\n", event)
+		return nil, nil, errors.Errorf("Event type is unknown - ignored: %v\n", eventType)
 	}
-	return nil
+
+	return &eventType, values, nil
 }
 
 // PreComplete updates the reading state machine based on a frame
-func (f *FrameReader) PreComplete(frame Frame) bool {
+func (f *FrameReader) PreComplete(frame Frame) (frameAccepted bool, err error) {
 	f.Stats.TotalFrames++
-	if frame.Size() <= logEventMaxFrameLength {
-		frameAccepted := f.Complete(frame)
-		if frameAccepted {
-			d := f.Stats.Frame[frame.Type()]
-			d.Bytes += int64(frame.Size())
-			d.ValidCount++
-			if d.SizeCount == nil {
-				d.SizeCount = map[int]int{}
-			}
-			d.SizeCount[frame.Size()]++
-			f.Stats.Frame[frame.Type()] = d
-			return true
-		}
 
-		d := f.Stats.Frame[frame.Type()]
-		d.DesyncCount++
-		f.Stats.Frame[frame.Type()] = d
-		return false
-
+	if frame.Size() > logEventMaxFrameLength {
+		f.countFrameAsCorrupted(frame)
+		return false, errors.Errorf(
+			"FrameReader: previous frame was corrupt, main stream is not valid anymore, frame size %d is bigger than expected %d",
+			frame.Size(),
+			logEventMaxFrameLength,
+		)
 	}
 
-	fmt.Printf("The previous frame was corrupt - Main stream is not valid anymore\n")
+	frameAccepted, err = f.Complete(frame)
+	if err != nil {
+		f.countFrameAsCorrupted(frame)
+		return frameAccepted, err
+	}
+
+	if frameAccepted {
+		d := f.Stats.Frame[frame.Type()]
+		d.Bytes += int64(frame.Size())
+		d.ValidCount++
+		if d.SizeCount == nil {
+			d.SizeCount = map[int]int{}
+		}
+		d.SizeCount[frame.Size()]++
+		f.Stats.Frame[frame.Type()] = d
+	}
+
+	d := f.Stats.Frame[frame.Type()]
+	d.DesyncCount++
+	f.Stats.Frame[frame.Type()] = d
+
+	return frameAccepted, nil
+}
+
+// Complete acknowledge and saves a frame
+func (f *FrameReader) Complete(frame Frame) (bool, error) {
+	switch frame.Type() {
+	case LogFrameIntra:
+		return f.completeFrameIntra(frame.(*MainFrame)), nil
+	case LogFrameInter:
+		return f.completeFrameInter(frame.(*MainFrame)), nil
+	case LogFrameSlow:
+		return f.completeSlowFrame(frame.(*SlowFrame)), nil
+	case LogFrameEvent:
+		return f.completeEventFrame(), nil
+	default:
+		return false, errors.Errorf("Unable to complete frame. Unsupported type '%s'.", string(frame.Type()))
+	}
+}
+
+func (f *FrameReader) countFrameAsCorrupted(frame Frame) {
 	f.MainStreamIsValid = false
 	d := f.Stats.Frame[frame.Type()]
 	d.CorruptCount++
 	f.Stats.Frame[frame.Type()] = d
 	f.Stats.TotalCorruptedFrames++
-	panic(frame.Size())
-}
-
-// Complete aknowledge and saves a frame
-func (f *FrameReader) Complete(frame Frame) bool {
-	switch frame.Type() {
-	case LogFrameIntra:
-		return f.completeFrameIntra(frame.(*MainFrame))
-	case LogFrameInter:
-		return f.completeFrameInter(frame.(*MainFrame))
-	case LogFrameSlow:
-		return f.completeSlowFrame(frame.(*SlowFrame))
-	case LogFrameEvent:
-		return f.completeEventFrame()
-	default:
-		panic(fmt.Sprintf("Unable to complete '%s'", string(frame.Type())))
-	}
 }
 
 func (f *FrameReader) completeFrameIntra(frame *MainFrame) bool {

--- a/src/blackbox/stats.go
+++ b/src/blackbox/stats.go
@@ -8,7 +8,7 @@ type StatsType struct {
 	Frame                         map[LogFrameType]StatsFrameType
 }
 
-// StatsFrameType represents stats for one type of freame
+// StatsFrameType represents stats for one type of frame
 type StatsFrameType struct {
 	ValidCount   int
 	Bytes        int64


### PR DESCRIPTION
- switched to byte type for frame and event types (separated commit)
- switched from panics to returned errors
- removed debugging prints (I didn't introduce `glog`, because after cleaning errors there were only couple of prints left, so I decided to just remove)