### PR TITLE
Add event name

### DIFF
--- a/src/blackbox/frame.go
+++ b/src/blackbox/frame.go
@@ -1,5 +1,39 @@
 package blackbox
 
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+var flightModeNames = map[int32]string{
+	1:   "ANGLE_MODE",
+	2:   "HORIZON_MODE",
+	4:   "MAG",
+	8:   "BARO",
+	16:  "GPS_HOME",
+	32:  "GPS_HOLD",
+	64:  "HEADFREE",
+	128: "AUTOTUNE",
+	256: "PASSTHRU",
+	512: "SONAR",
+}
+
+var flightStateNames = map[int32]string{
+	1:  "GPS_FIX_HOME",
+	2:  "GPS_FIX",
+	4:  "CALIBRATE_MAG",
+	8:  "SMALL_ANGLE",
+	16: "FIXED_WING",
+}
+
+var failsafePhaseNames = []string{
+	"IDLE",
+	"RX_LOSS_DETECTED",
+	"LANDING",
+	"LANDED",
+}
+
 // See https://cleanflight.readthedocs.io/en/stable/development/Blackbox%20Internals/
 
 type Frame interface {
@@ -73,6 +107,51 @@ func (f SlowFrame) Values() interface{} {
 	return f.values
 }
 
+func (f SlowFrame) StringValues() []string {
+	values := make([]string, len(f.values))
+	for k, v := range f.values {
+		values[k] = slowFrameFlagToString(k, v)
+	}
+	return values
+}
+
+func (f SlowFrame) String() string {
+	return fmt.Sprintf("S frame: %s", strings.Join(f.StringValues(), ", "))
+}
+
+func slowFrameFlagToString(fieldIndex int, value int32) string {
+	switch fieldIndex {
+	case 0:
+		return decodeFlagsToString(flightModeNames, value)
+	case 1:
+		return decodeFlagsToString(flightStateNames, value)
+	case 2:
+		return decodeEnumToString(failsafePhaseNames, value)
+	default:
+		return fmt.Sprintf("%d", value)
+	}
+}
+
+func decodeFlagsToString(flags map[int32]string, flagValue int32) string {
+	flagsAsStrings := []string{}
+	for k, v := range flags {
+		if flagValue&k == k {
+			flagsAsStrings = append(flagsAsStrings, v)
+		}
+	}
+	if len(flagsAsStrings) == 0 {
+		return "0"
+	}
+	return strings.Join(flagsAsStrings, "|")
+}
+
+func decodeEnumToString(enum []string, value int32) string {
+	if int(value) >= len(enum) {
+		return fmt.Sprintf("%d", value)
+	}
+	return enum[value]
+}
+
 // -------------------------------------------------------------------------- //
 
 type eventValues = map[string]interface{}
@@ -101,4 +180,14 @@ func (f EventFrame) Values() interface{} {
 
 func (f EventFrame) EventType() LogEventType {
 	return f.eventType
+}
+
+func (f EventFrame) String() string {
+	var values []string
+	for k, v := range f.Values().(map[string]interface{}) {
+		values = append(values, fmt.Sprintf("%s: '%v'", k, v))
+	}
+	sort.Strings(values)
+
+	return fmt.Sprintf("E frame: %s", strings.Join(values, ", "))
 }

--- a/src/blackbox/reader_frame.go
+++ b/src/blackbox/reader_frame.go
@@ -164,6 +164,7 @@ func (f *FrameReader) parseEventFrame(dec *stream.Decoder) (*LogEventType, event
 		if err != nil {
 			return nil, nil, err
 		}
+		values["name"] = "Sync beep"
 		values["beepTime"] = beepTime
 
 	case LogEventInflightAdjustment:
@@ -181,6 +182,7 @@ func (f *FrameReader) parseEventFrame(dec *stream.Decoder) (*LogEventType, event
 			return nil, nil, err
 		}
 		f.LoggingResumeCurrentTime = int32(val) + f.timeRolloverAccumulator
+		values["name"] = "Logging resume"
 		values["iteration"] = f.LoggingResumeLogIteration
 		values["currentTime"] = f.LoggingResumeCurrentTime
 
@@ -193,6 +195,7 @@ func (f *FrameReader) parseEventFrame(dec *stream.Decoder) (*LogEventType, event
 		if err != nil {
 			return nil, nil, err
 		}
+		values["name"] = "Flight mode"
 		values["flags"] = flags
 		values["lastFlags"] = lastFlags
 
@@ -210,6 +213,7 @@ func (f *FrameReader) parseEventFrame(dec *stream.Decoder) (*LogEventType, event
 			return nil, nil, errors.New("There are additional data after the end of the file")
 		}
 		f.Finished = true
+		values["name"] = "Log clean end"
 		values["data"] = val
 
 	default:

--- a/src/blackbox/reader_frame_test.go
+++ b/src/blackbox/reader_frame_test.go
@@ -54,6 +54,7 @@ func TestReadFrameEventLoggingResume(t *testing.T) {
 	expectedFrameValues := eventValues{
 		"currentTime": expectedTime,
 		"iteration":   expectedIteration,
+		"name":        "Logging resume",
 	}
 	expectedFrame := NewEventFrame(LogEventLoggingResume, expectedFrameValues, 0, 9)
 
@@ -76,6 +77,7 @@ func TestReadFrameEventSyncBeep(t *testing.T) {
 
 	expectedFrameValues := eventValues{
 		"beepTime": uint32(41780625),
+		"name":     "Sync beep",
 	}
 	expectedFrame := NewEventFrame(LogEventSyncBeep, expectedFrameValues, 0, 6)
 	assert.Equal(t, expectedFrame, frame)
@@ -95,6 +97,7 @@ func TestReadFrameEventLogEnd(t *testing.T) {
 
 	expectedFrameValues := eventValues{
 		"data": []byte{69, 110, 100, 32, 111, 102, 32, 108, 111, 103, 0, 0},
+		"name": "Log clean end",
 	}
 	expectedFrame := NewEventFrame(LogEventLogEnd, expectedFrameValues, 0, 12)
 	assert.Equal(t, expectedFrame, frame)

--- a/src/exporter/blackbox_decode/main.go
+++ b/src/exporter/blackbox_decode/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	cmd.Flags().IntVarP(&opts.verbose, "verbose", "v", 0, "Be verbose on log output")
 	cmd.Flags().BoolVarP(&opts.raw, "raw", "", false, "Don't apply predictions to fields (show raw field deltas)")
-	cmd.Flags().BoolVarP(&opts.raw, "debug", "", false, "Show extra debugging information")
+	cmd.Flags().BoolVarP(&opts.debug, "debug", "", false, "Show extra debugging information")
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/src/exporter/exporter/csv.go
+++ b/src/exporter/exporter/csv.go
@@ -97,11 +97,10 @@ func (e *CsvFrameExporter) WriteFrame(frame blackbox.Frame) error {
 
 		var values []string
 		for k, v := range frame.Values().(map[string]interface{}) {
-			values = append(values, fmt.Sprintf("%s: %d", k, v))
+			values = append(values, fmt.Sprintf("%s: '%v'", k, v))
 		}
 		sort.Strings(values)
 
-		//TODO: Output the event type
 		_, err := e.target.Write([]byte(fmt.Sprintf("E frame: %s", strings.Join(values, ", "))))
 		if err != nil {
 			return errors.Wrapf(err, "could not write frame '%s' to target file", string(frame.Type()))

--- a/src/exporter/exporter/csv.go
+++ b/src/exporter/exporter/csv.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"sort"
 	"strings"
 
 	"github.com/maxlaverse/blackbox-library/src/blackbox"
@@ -14,34 +13,6 @@ import (
 const (
 	adcVref = 33.0
 )
-
-var flightModeNames = map[int32]string{
-	1:   "ANGLE_MODE",
-	2:   "HORIZON_MODE",
-	4:   "MAG",
-	8:   "BARO",
-	16:  "GPS_HOME",
-	32:  "GPS_HOLD",
-	64:  "HEADFREE",
-	128: "AUTOTUNE",
-	256: "PASSTHRU",
-	512: "SONAR",
-}
-
-var flightStateNames = map[int32]string{
-	1:  "GPS_FIX_HOME",
-	2:  "GPS_FIX",
-	4:  "CALIBRATE_MAG",
-	8:  "SMALL_ANGLE",
-	16: "FIXED_WING",
-}
-
-var failsafePhaseNames = []string{
-	"IDLE",
-	"RX_LOSS_DETECTED",
-	"LANDING",
-	"LANDED",
-}
 
 var fieldUnits = map[blackbox.FieldName]string{
 	blackbox.FieldTime:             "us",
@@ -95,13 +66,7 @@ func (e *CsvFrameExporter) WriteFrame(frame blackbox.Frame) error {
 			return nil
 		}
 
-		var values []string
-		for k, v := range frame.Values().(map[string]interface{}) {
-			values = append(values, fmt.Sprintf("%s: '%v'", k, v))
-		}
-		sort.Strings(values)
-
-		_, err := e.target.Write([]byte(fmt.Sprintf("E frame: %s", strings.Join(values, ", "))))
+		_, err := e.target.Write([]byte(frame.(*blackbox.EventFrame).String()))
 		if err != nil {
 			return errors.Wrapf(err, "could not write frame '%s' to target file", string(frame.Type()))
 		}
@@ -113,11 +78,7 @@ func (e *CsvFrameExporter) WriteFrame(frame blackbox.Frame) error {
 			return nil
 		}
 
-		var values []string
-		for k, v := range e.lastSlow.Values().([]int32) {
-			values = append(values, flagStringValue(k, v))
-		}
-		_, err := e.target.Write([]byte(fmt.Sprintf("S frame: %s", strings.Join(values, ", "))))
+		_, err := e.target.Write([]byte(frame.(*blackbox.SlowFrame).String()))
 		if err != nil {
 			return errors.Wrapf(err, "could not write frame '%s' to target file", string(frame.Type()))
 		}
@@ -139,8 +100,8 @@ func (e *CsvFrameExporter) WriteFrame(frame blackbox.Frame) error {
 			}
 			values = append(values, prependSpaceForField(k, fmt.Sprintf("%d", v)))
 		}
-		for k, v := range e.lastSlow.Values().([]int32) {
-			values = append(values, flagStringValue(k, v))
+		for _, v := range e.lastSlow.StringValues() {
+			values = append(values, v)
 		}
 		_, err := e.target.Write([]byte(strings.Join(values, ", ")))
 		if err != nil {
@@ -183,37 +144,4 @@ func prependSpaceForField(index int, name string) string {
 	default:
 		return prependField(3, name)
 	}
-}
-
-func flagStringValue(fieldIndex int, value int32) string {
-	switch fieldIndex {
-	case 0:
-		return decodeFlagsToString(flightModeNames, value)
-	case 1:
-		return decodeFlagsToString(flightStateNames, value)
-	case 2:
-		return decodeEnumToString(failsafePhaseNames, value)
-	default:
-		return fmt.Sprintf("%d", value)
-	}
-}
-
-func decodeFlagsToString(flags map[int32]string, flagValue int32) string {
-	flagsAsStrings := []string{}
-	for k, v := range flags {
-		if flagValue&k == k {
-			flagsAsStrings = append(flagsAsStrings, v)
-		}
-	}
-	if len(flagsAsStrings) == 0 {
-		return "0"
-	}
-	return strings.Join(flagsAsStrings, "|")
-}
-
-func decodeEnumToString(enum []string, value int32) string {
-	if int(value) >= len(enum) {
-		return fmt.Sprintf("%d", value)
-	}
-	return enum[value]
 }

--- a/src/exporter/exporter/csv_test.go
+++ b/src/exporter/exporter/csv_test.go
@@ -31,16 +31,16 @@ func TestCsvHeaders(t *testing.T) {
 
 func TestRawValues(t *testing.T) {
 	expectedLines := []string{
-		"E frame: currentTime: 55158008, iteration: 52992\n",
+		"E frame: currentTime: '55158008', iteration: '52992', name: 'Logging resume'\n",
 		"52992, 55158008,  -1,  -4,  -1,   5,  -2,  -1,  -1, -30,   0,   0,   0,  -1,   0,   4, 1216,  -1,   0,   2, 216, -2.288, 15.200, 785,   0,   3,   3,  60,   8, 2232,  -5, -14,   1,   0, 333, 129,  -2, 144, 0, 0, IDLE, 0, 0\n",
-		"E frame: beepTime: 41780625\n",
-		"E frame: flags: 524289, lastFlags: 1\n",
+		"E frame: beepTime: '41780625', name: 'Sync beep'\n",
+		"E frame: flags: '524289', lastFlags: '1', name: 'Flight mode'\n",
 		"S frame: ANGLE_MODE, SMALL_ANGLE, IDLE, 1, 1\n",
 		"0, -2147483150,   1,   0,   1,   0,   0,   0,  -4,  -5,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  0.000,  0.000,   0,   0,   1,  -1,   0,  -2,  -1,   2,   5,  -2,   0,  -5,  16, -14,   4, ANGLE_MODE, SMALL_ANGLE, IDLE, 1, 1\n",
 		"0, -2147483648,   0,   1,  -1,   0,   0,   0,  -1,   4,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  0.000,  0.000,   0,  -1,   0,   1,   0,  -1,   0,   3,   9,   0,   0,   7,   0,   0,  -6, ANGLE_MODE, SMALL_ANGLE, IDLE, 1, 1\n",
 		"0, -2147483645,   2,   3,   0,   0,   0,   0,   4,  12,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  0.000,  0.000,   0,  -3,  -2,   1,   0,  -2,  -2,   1,   9,   1,   0,  24, -46,  43, -20, ANGLE_MODE, SMALL_ANGLE, IDLE, 1, 1\n",
 		"0, 2147483641,  -1,   3,   0,   0,   0,   0,   7,  20,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,  0.000,  0.000,   0,   0,  -4,   0,   0,  -1,  -1,   1,   9,   2,   0,  42, -79,  80, -41, ANGLE_MODE, SMALL_ANGLE, IDLE, 1, 1\n",
-		"E frame: data: [69 110 100 32 111 102 32 108 111 103 0 10]\n",
+		"E frame: data: '[69 110 100 32 111 102 32 108 111 103 0 10]', name: 'Log clean end'\n",
 	}
 
 	frameDef, frameChan, errChan, logFile := readFixture(t, "normal.bfl", blackbox.FlightLogReaderOpts{Raw: true})
@@ -66,16 +66,16 @@ func TestRawValues(t *testing.T) {
 
 func TestNormalValues(t *testing.T) {
 	expectedLines := []string{
-		"E frame: currentTime: 55158008, iteration: 52992\n",
+		"E frame: currentTime: '55158008', iteration: '52992', name: 'Logging resume'\n",
 		"52992, 55158008,  -1,  -4,  -1,   5,  -2,  -1,  -1, -30,   0,   0,   0,  -1,   0,   4, 1216,  -1,   0,   2, 216, 14.245, 15.200, 785,   0,   3,   3,  60,   8, 2232,  -5, -14,   1,   0, 521, 650, 519, 665, 0, 0, IDLE, 0, 0\n",
-		"E frame: beepTime: 41780625\n",
-		"E frame: flags: 524289, lastFlags: 1\n",
+		"E frame: beepTime: '41780625', name: 'Sync beep'\n",
+		"E frame: flags: '524289', lastFlags: '1', name: 'Flight mode'\n",
 		"S frame: ANGLE_MODE, SMALL_ANGLE, IDLE, 1, 1\n",
 		"52993, 55158507,   0,  -4,   0,   5,  -2,  -1,  -5, -35,   0,   0,   0,  -1,   0,   4, 1216,  -1,   0,   2, 216, 14.245, 15.200, 785,   0,   4,   2,  60,   6, 2231,  -3,  -9,  -1,   0, 516, 666, 505, 669, ANGLE_MODE, SMALL_ANGLE, IDLE, 1, 1\n",
 		"52994, 55159007,   0,  -3,  -1,   5,  -2,  -1,  -6, -31,   0,   0,   0,  -1,   0,   4, 1216,  -1,   0,   2, 216, 14.245, 15.200, 785,  -1,   3,   3,  60,   6, 2231,  -1,  -2,   0,   0, 525, 658, 512, 661, ANGLE_MODE, SMALL_ANGLE, IDLE, 1, 1\n",
 		"52995, 55159511,   2,   0,  -1,   5,  -2,  -1,  -2, -19,   0,   0,   0,  -1,   0,   4, 1216,  -1,   0,   2, 216, 14.245, 15.200, 785,  -3,   1,   3,  60,   4, 2229,  -1,   4,   1,   0, 544, 616, 551, 645, ANGLE_MODE, SMALL_ANGLE, IDLE, 1, 1\n",
 		"52996, 55160009,   1,   3,  -1,   5,  -2,  -1,   5,   1,   0,   0,   0,  -1,   0,   4, 1216,  -1,   0,   2, 216, 14.245, 15.200, 785,  -2,  -2,   3,  60,   4, 2229,   0,  10,   2,   0, 576, 558, 611, 612, ANGLE_MODE, SMALL_ANGLE, IDLE, 1, 1\n",
-		"E frame: data: [69 110 100 32 111 102 32 108 111 103 0 10]\n",
+		"E frame: data: '[69 110 100 32 111 102 32 108 111 103 0 10]', name: 'Log clean end'\n",
 	}
 
 	frameDef, frameChan, errChan, logFile := readFixture(t, "normal.bfl", blackbox.FlightLogReaderOpts{Raw: false})


### PR DESCRIPTION
* Adds a `name` field to the Event when dumped
* Move the dumping method of Slow and Event frames from the csv_exporter to the library
* Fix broken debug flag on the csv exporter